### PR TITLE
Fixed connection error in Firefox

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,6 +78,7 @@ module.exports = (env, argv) => ({
   },
   devServer: {
     contentBase: path.join(__dirname, 'dist'),
+    disableHostCheck: true,
     port: 9000,
     host: '0.0.0.0',
     hot: true


### PR DESCRIPTION
Сейчас сайт работает неправильно, если зайти с Firefox'а (и с ПК, и с телефона): не загружаются задачи, не нажимается кнопка "Создать"
В консоле возникает ошибка:
```
[WDS] Disconnected! client:172
      close client:172
      initSocket socket.js:26
```
![image](https://user-images.githubusercontent.com/15942162/94844448-727ec880-0448-11eb-8d34-ba5375be279c.png)

Немного погуглив, нашел интересные обсуждения [1](https://github.com/angular/angular-cli/issues/4839) и [2](https://github.com/webpack/webpack-dev-server/issues/1419)  
Какая-то беда у sockjs-node с проверкой сертификата  

Не самое лучшее решение, но зато заработает :roll_eyes: :roll_eyes: :roll_eyes: 